### PR TITLE
 Use yaml config files to drive auto-generation of snippets menu config and tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Get setup for GitHub
 
-(1) If you are new to GitHub, don't start here. Instead, work through a GitHub tutorial such as one of these:
+1. If you are new to GitHub, don't start here. Instead, work through a GitHub tutorial such as one of these:
     * https://guides.github.com/activities/hello-world/
     * http://r-pkgs.had.co.nz/git.html.
-
-(2) Follow [the instructions](https://github.com/all-of-us/workbench#git-secrets) to install [git-secrets](https://github.com/awslabs/git-secrets). Its a git commit hook that "Prevents you from committing passwords and other sensitive information to a git repository.".
+2. Follow [the instructions](https://github.com/all-of-us/workbench#git-secrets) to install [git-secrets](https://github.com/awslabs/git-secrets). Its a git commit hook that "Prevents you from committing passwords and other sensitive information to a git repository.".
 
 # How to contribute a snippet
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 1. If you are new to GitHub, don't start here. Instead, work through a GitHub tutorial such as one of these:
     * https://guides.github.com/activities/hello-world/
     * http://r-pkgs.had.co.nz/git.html.
-2. Follow [the instructions](https://github.com/all-of-us/workbench#git-secrets) to install [git-secrets](https://github.com/awslabs/git-secrets). Its a git commit hook that "Prevents you from committing passwords and other sensitive information to a git repository.".
+2. Follow [the instructions](https://github.com/all-of-us/workbench#git-secrets) to install [git-secrets](https://github.com/awslabs/git-secrets). Its a git commit hook that *"Prevents you from committing passwords and other sensitive information to a git repository."*.
 
 # How to contribute a snippet
 
@@ -18,6 +18,7 @@
     * Write it first in [ggplot2](https://ggplot2.tidyverse.org/) or [plotnine](https://plotnine.readthedocs.io/en/stable/), depending on your preference, and iterate until you like the look of it.
     * Once you have it the way you want it, port it to the other language.
     * Name the files `<my-query>_<viz-description>.ggplot` and `<my-query>_<viz-description>.plotnine`
+1. Update [r_snippets_menu_config.yml](build/r_snippets_menu_config.yml) and [py_snippets_menu_config.yml](build/py_snippets_menu_config.yml) to add your snippet where ever you would like it to be displayed within the menu.
 
 Don't like these conventions? We can change them! This is just a starting point. Keep in mind we'll need to reflect those changes in the auto-generation script described in the next section.
 
@@ -32,7 +33,7 @@ For more detail, see the [Snippets Menu](https://jupyter-contrib-nbextensions.re
     python3 ./generate_jupyter_snippets_menu_extension_config.py
     # If you get an error about a missing jinja2 library, run command 'pip3 install --user jinja2'
     ```
-1. Then copy and paste the contents of the newly created file `jupyter_snippets_menu_extension_config.json` to form field '*JSON string parsed to define custom menus (only used if the option above is checked)*' in the Snippets Menu extension configuration.
+1. Then copy and paste the contents of the newly created file `r_jupyter_snippets_menu_extension_config.json` or `py_jupyter_snippets_menu_extension_config.json` into form field '*JSON string parsed to define custom menus (only used if the option above is checked)*' in the Snippets Menu extension configuration.
 
 # Testing
 

--- a/build/generate_jupyter_snippets_menu_extension_config.py
+++ b/build/generate_jupyter_snippets_menu_extension_config.py
@@ -1,4 +1,4 @@
-"""Auto-generate AoU configuration for Jupyter 'Snippets Menu' extension.
+"""Auto-generate All of Us configuration for Jupyter 'Snippets Menu' extension.
 
 Additionally, create smoke test scripts for both R and Python that include all
 the snippets.
@@ -9,17 +9,14 @@ See also: https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextens
 import jinja2
 import json
 import os
-
-# Output files.
-JSON_OUTPUT = 'jupyter_snippets_menu_extension_config.json'
-R_SMOKE_TEST = 'smoke_test.R'
-PY_SMOKE_TEST = 'smoke_test.py'
+import yaml
 
 # Input file directory.
-SNIPPETS_ROOT = '../snippets'
+SNIPPETS_ROOT = '../'
 
-# R configuration constants.
-R_SETUP_SNIPPET = 'snippets_setup.R'
+R_MENU_CONFIG = './r_snippets_menu_config.yml'
+PY_MENU_CONFIG = './py_snippets_menu_config.yml'
+
 R_QUERY_TEMPLATE = '''
 {{ dataframe }} <- bq_table_download(bq_project_query(
     BILLING_PROJECT_ID,
@@ -30,92 +27,86 @@ print(skim({{ dataframe }}))
 head({{ dataframe }})
 '''
 
-# Python configuration constants.
-PY_SETUP_SNIPPET = 'snippets_setup.py'
 PY_QUERY_TEMPLATE = """
 {{ dataframe }} = pd.io.gbq.read_gbq(f'''
 {{ query }}
 ''',
-  project_id=BILLING_PROJECT_ID,
   dialect='standard')
 
 {{ dataframe }}.head()
 """
 
-r_setup_snippet = {
-  'name': 'Setup',
-  'snippet': open(os.path.join(SNIPPETS_ROOT, R_SETUP_SNIPPET), 'r').read()
-}
+R_SHEBANG = '#!/usr/bin/env Rscript\n\n'
+PY_SHEBANG = '#!/usr/bin/env python3\n\n'
 
-py_setup_snippet = {
-  'name': 'Setup',
-  'snippet': open(os.path.join(SNIPPETS_ROOT, PY_SETUP_SNIPPET), 'r').read()
-}
+# Output files.
+R_JSON_OUTPUT = 'r_jupyter_snippets_menu_extension_config.json'
+PY_JSON_OUTPUT = 'py_jupyter_snippets_menu_extension_config.json'
+R_SMOKE_TEST = 'smoke_test.R'
+PY_SMOKE_TEST = 'smoke_test.py'
 
-r_snippets_config = {
-  'name': 'All of Us R snippets',
-  'sub-menu': [r_setup_snippet]  # The loop below will add more here.
-}
 
-py_snippets_config = {
-  'name': 'All of Us Py snippets',
-  'sub-menu': [py_setup_snippet]  # The loop below will add more here.
-}
+def generate_config(d, query_template, smoke_test_fh):
+  """Given a dictionary, convert that to snippets menu configuration."""
+  for key, value in d.items():
+    if isinstance(value, list):
+      return {
+          'name': key,
+          'sub-menu': [generate_config(x, query_template, smoke_test_fh)
+                       for x in value]
+      }
 
-snippets_config = {
-  'name': 'All of Us snipppets',
-  'sub-menu': [r_snippets_config, py_snippets_config]
-}
+    if value == 'divider':
+      return '---'
 
-for root, dirs, files in os.walk(SNIPPETS_ROOT):
-  # This sort, along with our filenaming convention, ensures that the SQL
-  # snippet will occur before the dependent plot snippets.
-  files.sort()
+    if value.startswith('http'):
+      return {
+          'name': key,
+          'external-link': value
+      }
 
-  for filename in files:
-    # This file may or may not be used for a snippet in a particular language.
-    r_code_snippet = None
-    py_code_snippet = None
+    if os.path.isfile(os.path.join(SNIPPETS_ROOT, value)):
+      if value.endswith('.sql'):
+        # Render SQL to snippets in the desired language.
+        sql = open(os.path.join(SNIPPETS_ROOT, value), 'r').read()
+        dataframe_name = os.path.splitext(os.path.basename(value))[0] + '_df'
+        code = jinja2.Template(query_template).render(
+            {'dataframe': dataframe_name, 'query': sql})
+      else:
+        # Its a non-sql file, just read it in.
+        code = open(os.path.join(SNIPPETS_ROOT, value), 'r').read()
 
-    # Render SQL to snippets in both languages.
-    if filename.endswith('.sql'):
-      sql = open(os.path.join(SNIPPETS_ROOT, filename), 'r').read()
-      r_code_snippet = jinja2.Template(R_QUERY_TEMPLATE).render(
-          {'dataframe': filename.replace('.sql', '_df'), 'query': sql})
-      py_code_snippet = jinja2.Template(PY_QUERY_TEMPLATE).render(
-          {'dataframe': filename.replace('.sql', '_df'), 'query': sql})
+      smoke_test_fh.write('#---[ This is snippet: {} ]---\n{}\n\n'.format(key,
+                                                                          code))
+      return {
+          'name': key,
+          'snippet': code
+      }
 
-    elif filename.endswith('.ggplot'):
-      r_code_snippet = open(os.path.join(SNIPPETS_ROOT, filename), 'r').read()
+    # Its not a file, so we will use the value directly.
+    return {
+        'name': key,
+        'snippet': value
+    }
 
-    elif filename.endswith('.plotnine'):
-      py_code_snippet = open(os.path.join(SNIPPETS_ROOT, filename), 'r').read()
 
-    if r_code_snippet is not None:
-      snippet = {}
-      snippet['name'] = filename
-      snippet['snippet'] = r_code_snippet
-      r_snippets_config['sub-menu'].append(snippet)
+def render_files(config_file, query_template, output_file,
+                 shebang, smoke_test_file):
+  """Use configuration to drive the autogeneration of snippets and tests."""
+  with open(config_file, 'r') as f:
+    config = yaml.load(f.read())
 
-    if py_code_snippet is not None:
-      snippet = {}
-      snippet['name'] = filename
-      snippet['snippet'] = py_code_snippet
-      py_snippets_config['sub-menu'].append(snippet)
+  print(yaml.dump(config))
 
-with open(JSON_OUTPUT, 'w') as f:
-  json.dump(snippets_config, f)
+  with open(smoke_test_file, 'w') as f:
+    f.write(shebang)
+    snippets_config = generate_config(config, query_template, f)
+    f.write('\nprint("Smoke test complete!")')
 
-with open(R_SMOKE_TEST, 'w') as f:
-  f.write('#!/usr/bin/env Rscript\n\n')
-  for snippet in r_snippets_config['sub-menu']:
-    f.write('#---[ This is snippet: {} ]---\n{}\n\n'.format(snippet['name'],
-                                                            snippet['snippet']))
-  f.write('\nprint("Smoke test complete!")')
+  with open(output_file, 'w') as f:
+    json.dump(snippets_config, f)
 
-with open(PY_SMOKE_TEST, 'w') as f:
-  f.write('#!/usr/bin/env python3\n\n')
-  for snippet in py_snippets_config['sub-menu']:
-    f.write('#---[ This is snippet: {} ]---\n{}\n\n'.format(snippet['name'],
-                                                            snippet['snippet']))
-  f.write('\nprint("Smoke test complete!")')
+render_files(R_MENU_CONFIG, R_QUERY_TEMPLATE, R_JSON_OUTPUT,
+             R_SHEBANG, R_SMOKE_TEST)
+render_files(PY_MENU_CONFIG, PY_QUERY_TEMPLATE, PY_JSON_OUTPUT,
+             PY_SHEBANG, PY_SMOKE_TEST)

--- a/build/generate_jupyter_snippets_menu_extension_config.py
+++ b/build/generate_jupyter_snippets_menu_extension_config.py
@@ -73,7 +73,7 @@ def generate_config(d, query_template, smoke_test_fh):
         code = jinja2.Template(query_template).render(
             {'dataframe': dataframe_name, 'query': sql})
       else:
-        # Its a non-sql file, just read it in.
+        # It's a non-sql file, just read it in.
         code = open(os.path.join(SNIPPETS_ROOT, value), 'r').read()
 
       smoke_test_fh.write('#---[ This is snippet: {} ]---\n{}\n\n'.format(key,

--- a/build/py_snippets_menu_config.yml
+++ b/build/py_snippets_menu_config.yml
@@ -1,0 +1,20 @@
+All of Us Py snippets:
+  - Setup: snippets/snippets_setup.py
+  - Documentation: https://github.com/all-of-us/workbench-snippets
+  - divider: divider
+  - Participant counts:
+    - total_number_of_participants.sql: snippets/total_number_of_participants.sql
+    - number_of_participants_with_measurements.sql: snippets/number_of_participants_with_measurements.sql
+    - number_of_participants_with_med_conditions.sql: snippets/number_of_participants_with_med_conditions.sql
+  - Summarize available measurements of interest:
+    - measurements_of_interest_summary.sql: snippets/measurements_of_interest_summary.sql
+  - Retrieve a measurement of interest:
+    - measurement_of_interest.sql: snippets/measurement_of_interest.sql
+    - measurement_of_interest_by_age_and_gender.plotnine: snippets/measurement_of_interest_by_age_and_gender.plotnine
+    - measurement_of_interest_by_gender.plotnine: snippets/measurement_of_interest_by_gender.plotnine
+    - measurement_of_interest_by_site.plotnine: snippets/measurement_of_interest_by_site.plotnine
+  - Retrieve the most recent measurement of interest per person:
+    - most_recent_measurement_of_interest.sql: snippets/most_recent_measurement_of_interest.sql
+    - most_recent_measurement_of_interest_by_age_and_gender.plotnine: snippets/most_recent_measurement_of_interest_by_age_and_gender.plotnine
+    - most_recent_measurement_of_interest_by_gender.plotnine: snippets/most_recent_measurement_of_interest_by_gender.plotnine
+    - most_recent_measurement_of_interest_by_site.plotnine: snippets/most_recent_measurement_of_interest_by_site.plotnine

--- a/build/r_snippets_menu_config.yml
+++ b/build/r_snippets_menu_config.yml
@@ -1,0 +1,20 @@
+All of Us R snippets:
+  - Setup: snippets/snippets_setup.R
+  - Documentation: https://github.com/all-of-us/workbench-snippets
+  - divider: divider
+  - Participant counts:
+    - total_number_of_participants.sql: snippets/total_number_of_participants.sql
+    - number_of_participants_with_measurements.sql: snippets/number_of_participants_with_measurements.sql
+    - number_of_participants_with_med_conditions.sql: snippets/number_of_participants_with_med_conditions.sql
+  - Summarize available measurements of interest:
+    - measurements_of_interest_summary.sql: snippets/measurements_of_interest_summary.sql
+  - Retrieve a measurement of interest:
+    - measurement_of_interest.sql: snippets/measurement_of_interest.sql
+    - measurement_of_interest_by_age_and_gender.ggplot: snippets/measurement_of_interest_by_age_and_gender.ggplot
+    - measurement_of_interest_by_gender.ggplot: snippets/measurement_of_interest_by_gender.ggplot
+    - measurement_of_interest_by_site.ggplot: snippets/measurement_of_interest_by_site.ggplot
+  - Retrieve the most recent measurement of interest per person:
+    - most_recent_measurement_of_interest.sql: snippets/most_recent_measurement_of_interest.sql
+    - most_recent_measurement_of_interest_by_age_and_gender.ggplot: snippets/most_recent_measurement_of_interest_by_age_and_gender.ggplot
+    - most_recent_measurement_of_interest_by_gender.ggplot: snippets/most_recent_measurement_of_interest_by_gender.ggplot
+    - most_recent_measurement_of_interest_by_site.ggplot: snippets/most_recent_measurement_of_interest_by_site.ggplot


### PR DESCRIPTION
The revised auto-generation script now facilitates:
* output of separate snippets menu config files for R and Python
* links to external documentation
* dividers (e.g. add a horizontal line between the Setup snippet and the others)

The yaml config file that drives it:
* decouples the snippet name from the source filename of the snippet
* decouples the path in source control for the file of code from where it resides in the snippets menu
* facilitates arbitrary grouping of related snippets

Updates to README.md to follow in a separate PR.