### PR TITLE
Remove obsolete comments.

### DIFF
--- a/storage-snippets/interact_with_html_snapshots.py
+++ b/storage-snippets/interact_with_html_snapshots.py
@@ -1,6 +1,4 @@
 from terra_widgets.html_snapshots import display_html_snapshots_widget
-# You may see some 'FutureWarning' messages emitted by Tensorflow and numpy. These are
-# safe to ignore and will go away the next time the base image updates its package versions.
 
 # This will display a user interface to interact with HTML snapshots stored in the workspace bucket.
 display_html_snapshots_widget()


### PR DESCRIPTION
The warnings mentioned by the obsolete comment no longer appear.