### PR TITLE
Update the default measurement of interest to be Hemoglobin A1c.

### DIFF
--- a/sql-snippets/snippets_setup.R
+++ b/sql-snippets/snippets_setup.R
@@ -31,7 +31,7 @@ COHORT_QUERY <- str_glue('SELECT person_id FROM `{CDR}.person`')  # Default to a
 MEASUREMENT_OF_INTEREST <- 'hemoglobin'
 # Tip: the next four parameters could be set programmatically using one row from
 # the result of measurements_of_interest_summary.sql
-MEASUREMENT_CONCEPT_ID <- 3000963        # Hemoglobin
-UNIT_CONCEPT_ID <- 8636                  # gram per liter
+MEASUREMENT_CONCEPT_ID <- 3004410        # Hemoglobin A1c
+UNIT_CONCEPT_ID <- 8554                  # percent
 MEASUREMENT_NAME <- '<this should be the measurement name>'
 UNIT_NAME <- '<this should be the unit name>'

--- a/sql-snippets/snippets_setup.py
+++ b/sql-snippets/snippets_setup.py
@@ -28,7 +28,7 @@ COHORT_QUERY = f'SELECT person_id FROM `{CDR}.person`'  # Default to all partici
 MEASUREMENT_OF_INTEREST = 'hemoglobin'
 # Tip: the next four parameters could be set programmatically using one row from
 # the result of measurements_of_interest_summary.sql
-MEASUREMENT_CONCEPT_ID = 3000963        # Hemoglobin
-UNIT_CONCEPT_ID = 8636                  # gram per liter
+MEASUREMENT_CONCEPT_ID = 3004410        # Hemoglobin A1c
+UNIT_CONCEPT_ID = 8554                  # percent
 MEASUREMENT_NAME = '<this should be the measurement name>'
 UNIT_NAME = '<this should be the unit name>'


### PR DESCRIPTION
The primary reason to do this was to use a measure found in both the real data and the synthetic data, but I also think its a better default measure to use.

* See what the plots look like [here](https://workbench.researchallofus.org/workspaces/aou-rw-cedbb7be/testanddevelopcodesnippetsonaouv4/notebooks/Hemaglobin%20A1c.ipynb).
* See the successful smoke test run [here](https://notebooks.firecloud.org/notebooks/aou-rw-cedbb7be/all-of-us-35/notebooks/workspaces/testanddevelopcodesnippetsonaouv4/Test%20snippets.ipynb).


Unfortunately we don't have automated testing configured for the code in this
repository yet so we set up this checklist as an *automatic reminder*:

- [X] Ensure that the smoke tests pass using the current (or upcoming) CDR
- [X] Update documentation relevant to this pull request

Questions? See [CONTRIBUTING.md](https://github.com/all-of-us/workbench-snippets/blob/master/CONTRIBUTING.md)
or file an issue so that we can get it documented!
