### PR TITLE
Update lower bound for tensorflow to be a release.

### DIFF
--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -2,4 +2,4 @@ firecloud>=0.16.25
 ipython>=5.7.0
 ipywidgets>=7.5.1
 pandas>=0.25.3
-tensorflow>=2.0.0-alpha0
+tensorflow>=2.0.0


### PR DESCRIPTION
Use of a release candidate appears to be causing this issue https://github.com/DataBiosphere/terra-docker/pull/208#issuecomment-813596463

I confirmed the fix via https://github.com/deflaux/terra-docker/actions/runs/720234301 pointing to this branch.