### PR TITLE
Require only tensorflow support for cpus.

### DIFF
--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -2,4 +2,4 @@ firecloud>=0.16.25
 ipython>=5.7.0
 ipywidgets>=7.5.1
 pandas>=0.25.3
-tensorflow>=2.0.0
+tensorflow_cpu>=2.0.0


### PR DESCRIPTION
The requirements in package are causing [terra-jupyter-aou](https://github.com/DataBiosphere/terra-docker/blob/68756bfde287c185711b56d1b751ff81ec6532c4/terra-jupyter-aou/Dockerfile#L138) to pull in the gpu version of tensorflow, which is unnecessary and causing [test failures](https://github.com/DataBiosphere/terra-docker/pull/217). This package only uses the gfile methods within tensorflow.

See the [test of this branch](https://github.com/deflaux/terra-docker/commit/ea3db044be3c823da031bb833c38b8cddd85127f) and [passing test results](https://github.com/deflaux/terra-docker/actions/runs/876527374).