### PR TITLE
IA-2686 downgrade tensorflow version requirement 

### DIFF
--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -2,4 +2,4 @@ firecloud>=0.16.25
 ipython>=5.7.0
 ipywidgets>=7.5.1
 pandas>=0.25.3
-tensorflow>=2.5.0
+tensorflow>=2.4.2


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2686

Tensorflow 2.5 will require CUDA 11.2, which isn't supported by Google's deep learning image stack yet.
Hence, downgrade it to tensorflow 2.4.2 which will work with CUDA 11.0.


Unfortunately we don't have automated testing configured for the code in this
repository yet so we set up this checklist as an *automatic reminder*:

- [ ] Ensure that the smoke tests pass using the current (or upcoming) CDR
- [ ] Update documentation relevant to this pull request

Questions? See [CONTRIBUTING.md](https://github.com/all-of-us/workbench-snippets/blob/master/CONTRIBUTING.md)
or file an issue so that we can get it documented!
