### PR TITLE
Remove tensorflow dependency.

### DIFF
--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -2,4 +2,3 @@ firecloud>=0.16.25
 ipython>=5.7.0
 ipywidgets>=7.5.1
 pandas>=0.25.3
-tensorflow>=2.4.2


### PR DESCRIPTION
All the environments where this package are installed already have tensorflow preinstalled.

Technically, `tensorflow` should be in `requirements.txt` due to the use of `tf.gfile` by this package, but in practice it has repeatedly caused issues with the pip install. You can see in the [terra-jupyter-aou tests](https://github.com/deflaux/terra-docker/actions/runs/980211178) that removing the requirement fixes the current issue with the build.
