### PR TITLE
Parallelize retrieval of snapshot comments.

### DIFF
--- a/py/requirements.txt
+++ b/py/requirements.txt
@@ -1,4 +1,5 @@
-firecloud>=0.16.25
-ipython>=5.7.0
-ipywidgets>=7.5.1
-pandas>=0.25.3
+firecloud
+ipython
+ipywidgets
+multiprocess
+pandas

--- a/py/terra_widgets/html_snapshots.py
+++ b/py/terra_widgets/html_snapshots.py
@@ -15,8 +15,10 @@ from IPython.display import display
 from IPython.display import HTML
 from IPython.display import IFrame
 from ipywidgets import widgets
+from multiprocess import Pool
 import pandas as pd
 import tensorflow as tf
+from tqdm import tqdm
 
 from terra_widgets.workspace_metadata import WorkspaceMetadata
 from terra_widgets.workspace_paths import WorkspacePaths
@@ -294,28 +296,23 @@ def create_view_all_comments_widget(ws_names2id: Dict[str, str], ws_paths: Dict[
         display(HTML('''<div class="alert alert-block alert-warning">
           No comment files found for HTML snapshots in this workspace.</div>'''))
         return
-      progress = widgets.IntProgress(
-          value=0,
-          min=0,
-          max=len(comment_files),
-          step=1,
-          description=f'Retrieving {len(comment_files)} comments:',
-          bar_style='success',
-          orientation='horizontal',
-          layout=widgets.Layout(width='450px'),
-          style={'description_width': 'initial'}
-      )
-      display(progress)
-      comment_num = 0
-      comment_file_contents = []
-      for file in comment_files:
-        comment = get_ipython().getoutput(f"gsutil cat '{file}'")
-        version = file.replace(workspace_paths.get_subfolder(), '')
-        comment_file_contents.append({'version': version, 'comment': comment})
-        comment_num += 1
-        progress.value = comment_num
-      comments = pd.DataFrame(comment_file_contents)
-      display(comments)
+
+      def get_comment(f):
+        return get_ipython().getoutput(f"gsutil cat '{f}'")
+
+      def process_task(f):
+        return f, get_comment(f)
+
+      max_pool = 16
+      with Pool(max_pool) as p:
+        pool_outputs = list(tqdm(p.imap(process_task, comment_files), total=len(comment_files)))
+
+      comments = pd.DataFrame.from_dict({f.replace(workspace_paths.get_subfolder(), ''): c[0] for f, c in pool_outputs},
+                                        orient = 'index',
+                                        columns = ['comment']
+                                       ).reset_index()
+      comments[['extra', 'author', 'date', 'time', 'item']] = comments['index'].str.split(pat='/', expand=True)
+      display(comments[['date', 'time', 'author', 'item', 'comment']].sort_values(by=['date', 'time']))
   workspace_chooser.observe(on_choose_workspace, names='value')
 
   return widgets.VBox(
@@ -331,15 +328,13 @@ def create_view_all_comments_widget(ws_names2id: Dict[str, str], ws_paths: Dict[
 def display_html_snapshots_widget():
   """Create an ipywidget UI encapsulating all three UIs related to HTML snapshots."""
   if not get_ipython():
-    print('The HTML snapshot widget cannot be display in environments other than IPython.') 
+    print('The HTML snapshot widget cannot be display in environments other than IPython.')
     return
 
   # Configure notebook display preferences to better suit this UI. These display settings
   # will be in effect for all cells in the notebook run after this one is run.
-  if pd.__version__.startswith('1'):
-    pd.set_option('display.max_colwidth', None)
-  else:
-    pd.set_option('display.max_colwidth', -1)
+  pd.set_option('display.max_colwidth', None)
+  pd.set_option('display.max_rows', None)
   get_ipython().run_cell_magic(
       'javascript',
       '',

--- a/py/terra_widgets/html_snapshots.py
+++ b/py/terra_widgets/html_snapshots.py
@@ -321,7 +321,7 @@ def create_view_all_comments_widget(ws_names2id: Dict[str, str], ws_paths: Dict[
                                         columns = ['comment']
                                        ).reset_index()
       comments[['extra', 'author', 'date', 'time', 'item']] = comments['index'].str.split(pat='/', expand=True)
-      display(comments[['date', 'time', 'author', 'item', 'comment']].sort_values(by=['date', 'time']))
+      display(comments[['date', 'time', 'author', 'item', 'comment']].sort_values(by=['date', 'time']).reset_index(drop=True))
   workspace_chooser.observe(on_choose_workspace, names='value')
 
   return widgets.VBox(


### PR DESCRIPTION
Fixes https://github.com/all-of-us/workbench-snippets/issues/54

For a workspace making heavy use of HTML snapshots, the show all comments tab was taking more than 3 minutes to display its output for 72 snapshots. Now it takes less than two seconds! The biggest gain was made by switching from using `gsutil` for the repetitive task to using a Python GCS library, but the addition of `multiprocess` also helps with the speed up.

Unfortunately we don't have automated testing configured for the code in this
repository yet so we set up this checklist as an *automatic reminder*:

- [X ] Ensure that the smoke tests pass using the current (or upcoming) CDR
- [X ] Update documentation relevant to this pull request

Questions? See [CONTRIBUTING.md](https://github.com/all-of-us/workbench-snippets/blob/master/CONTRIBUTING.md)
or file an issue so that we can get it documented!
