### PR TITLE
R cohort codegen sample

### DIFF
--- a/dataset-snippets/codegen_sample.r
+++ b/dataset-snippets/codegen_sample.r
@@ -89,20 +89,23 @@ bq_table_save(
   destination_format = "CSV")
 
 # Read the data directly from Cloud Storage into memory.
-# NOTE: Alternatively you can `gsutil -m cp {survey_export_15947426_path}` to copy these files
+# NOTE: Alternatively you can `gsutil -m cp {survey_export_15947426_path} .` to copy these files
 #       to the Jupyter disk.
-col_types <- NULL
-dataset_15947426_survey_df <- bind_rows(
-  map(system2('gsutil', args = c('ls', survey_export_15947426_path), stdout = TRUE, stderr = TRUE),
-      function(csv) {
-        message(str_glue('Loading {csv}.'))
-        chunk <- read_csv(pipe(str_glue('gsutil cat {csv}')), col_types = col_types, show_col_types = FALSE)
-        if (is.null(col_types)) {
-          col_types <- spec(chunk)    
-        }
-        chunk
-      })
-)
+read_bq_export_from_workspace_bucket <- function(export_path) {
+    col_types <- NULL
+    bind_rows(
+        map(system2('gsutil', args = c('ls', export_path), stdout = TRUE, stderr = TRUE),
+            function(csv) {
+                message(str_glue('Loading {csv}.'))
+                chunk <- read_csv(pipe(str_glue('gsutil cat {csv}')), col_types = col_types, show_col_types = FALSE)
+                if (is.null(col_types)) {
+                    col_types <- spec(chunk)    
+                }
+                chunk
+            })
+    )
+}
+dataset_15947426_survey_df <- read_bq_export_from_workspace_bucket(survey_export_15947426_path)
 
 dim(dataset_15947426_survey_df)
 

--- a/dataset-snippets/codegen_sample.r
+++ b/dataset-snippets/codegen_sample.r
@@ -70,35 +70,35 @@ AND (
 # NOTE: By default data exported multiple times on the same day will overwrite older copies.
 #       But data exported on a different days will write to a new location so that historical
 #       copies can be kept as the dataset definition is changed.
-survey_export_87319558_path <- file.path(
-    Sys.getenv("WORKSPACE_BUCKET"),
-    "bq_exports",
-    Sys.getenv("OWNER_EMAIL"),
-    strftime(lubridate::now(), "%Y%m%d"),  # Comment out this line if you want the export to always overwrite.
-    "survey_87319558",
-    "survey_87319558_*.csv")
-message(str_glue('The data will be written to {survey_export_87319558_path}. Use this path when reading ',
+survey_export_15947426_path <- file.path(
+  Sys.getenv("WORKSPACE_BUCKET"),
+  "bq_exports",
+  Sys.getenv("OWNER_EMAIL"),
+  strftime(lubridate::now(), "%Y%m%d"),  # Comment out this line if you want the export to always overwrite.
+  "survey_15947426",
+  "survey_15947426_*.csv")
+message(str_glue('The data will be written to {survey_export_15947426_path}. Use this path when reading ',
                  'the data into your notebooks in the future.'))
 
 # Perform the query and export the dataset to Cloud Storage as CSV files.
 # NOTE: You only need to run `bq_table_save` once. After that, you can
 #       just read data from the CSVs in Cloud Storage.
 bq_table_save(
-    bq_dataset_query(Sys.getenv("WORKSPACE_CDR"), dataset_87319558_survey_sql, billing = Sys.getenv("GOOGLE_PROJECT")),
-    survey_export_87319558_path,
-    destination_format = "CSV")
+  bq_dataset_query(Sys.getenv("WORKSPACE_CDR"), dataset_15947426_survey_sql, billing = Sys.getenv("GOOGLE_PROJECT")),
+  survey_export_15947426_path,
+  destination_format = "CSV")
 
 # Read the data directly from Cloud Storage into memory.
-# NOTE: Alternatively you can `gsutil -m cp {survey_export_87319558_path}` to copy these files
+# NOTE: Alternatively you can `gsutil -m cp {survey_export_15947426_path}` to copy these files
 #       to the Jupyter disk.
-dataset_87319558_survey_df <- bind_rows(
-    map(system2('gsutil', args = c('ls', survey_export_87319558_path), stdout = TRUE, stderr = TRUE),
-        function(csv) {
-            message(str_glue('Loading {csv}.'))
-            read_csv(pipe(str_glue('gsutil cat {csv}')))
-        })
-    )
+dataset_15947426_survey_df <- bind_rows(
+  map(system2('gsutil', args = c('ls', survey_export_15947426_path), stdout = TRUE, stderr = TRUE),
+      function(csv) {
+        message(str_glue('Loading {csv}.'))
+        read_csv(pipe(str_glue('gsutil cat {csv}')))
+      })
+)
 
-dim(dataset_87319558_survey_df)
+dim(dataset_15947426_survey_df)
 
-head(dataset_87319558_survey_df)
+head(dataset_15947426_survey_df)

--- a/dataset-snippets/codegen_sample.r
+++ b/dataset-snippets/codegen_sample.r
@@ -78,9 +78,9 @@ bq_table_save(
 
 # Copy the CSV file(s) to the local VM file system.
 dir.create(out_dir_15947426)
-system2("gsutil", paste("-m", "cp", export_15947426_path, paste(out_dir_15947426, "/"), stdout=TRUE, stderr=TRUE)
+system2("gsutil", paste("-m", "cp", export_15947426_path, paste(out_dir_15947426, "/")), stdout=TRUE, stderr=TRUE)
 
 # Load the local CSV file(s) as a data frame.
-dataset_15947426_survey_df = data.table::rbindlist(lapply(Sys.glob(export_15947426_glob), data.table::fread))
+dataset_15947426_survey_df <- data.table::rbindlist(lapply(Sys.glob(export_15947426_glob), data.table::fread))
 
 head(dataset_15947426_survey_df)

--- a/dataset-snippets/codegen_sample.r
+++ b/dataset-snippets/codegen_sample.r
@@ -1,0 +1,86 @@
+library(tidyverse)
+library(bigrquery)
+
+# This query represents dataset "asdf" for domain "survey" and was generated for Synthetic Dataset in the Controlled Tier
+dataset_15947426_survey_sql <- paste("
+    SELECT
+        answer.person_id,
+        answer.survey_datetime,
+        answer.survey,
+        answer.question_concept_id,
+        answer.question,
+        answer.answer_concept_id,
+        answer.answer,
+        answer.survey_version_concept_id,
+        answer.survey_version_name  
+    FROM
+        `ds_survey` answer   
+    WHERE
+        (
+            question_concept_id IN (
+                SELECT
+                    DISTINCT(question_concept_id) as concept_id  
+                FROM
+                    `ds_survey` 
+            )
+        )  
+AND (
+            answer.PERSON_ID IN (
+                SELECT
+                    person_id  
+                FROM
+                    `cb_search_person` cb_search_person  
+                WHERE
+                    cb_search_person.person_id IN (
+                        SELECT
+                            person_id 
+                        FROM
+                            `cb_search_person` p 
+                        WHERE
+                            has_whole_genome_variant = 1 
+                    ) 
+                    AND cb_search_person.person_id IN (
+                        SELECT
+                            person_id 
+                        FROM
+                            `cb_search_person` p 
+                        WHERE
+                            DATE_DIFF(CURRENT_DATE,dob, YEAR) - IF(EXTRACT(MONTH 
+                        FROM
+                            dob)*100 + EXTRACT(DAY 
+                        FROM
+                            dob) > EXTRACT(MONTH 
+                        FROM
+                            CURRENT_DATE)*100 + EXTRACT(DAY 
+                        FROM
+                            CURRENT_DATE),
+                            1,
+                            0) BETWEEN 18 AND 24 
+                            AND NOT EXISTS ( SELECT
+                                'x' 
+                            FROM
+                                `death` d 
+                            WHERE
+                                d.person_id = p.person_id) ) 
+                    )
+                )
+ ", sep="")
+
+# Extract the cohort to Cloud Storage as CSV.
+out_dir_15947426 <- "out_15947426"
+export_15947426_glob <- paste(out_dir_15947426, "/export15947426-*.csv")
+export_15947426_path <- paste(Sys.getenv("WORKSPACE_BUCKET"), "/bq_exports/", export_15947426_glob, sep="")
+bq_table_save(
+    bq_dataset_query(Sys.getenv("WORKSPACE_CDR"), dataset_15947426_survey_sql, billing=Sys.getenv("GOOGLE_PROJECT")),
+    export_15947426_path,
+    destination_format="CSV"
+)
+
+# Copy the CSV file(s) to the local VM file system.
+dir.create(out_dir_15947426)
+system2("gsutil", paste("-m", "cp", export_15947426_path, paste(out_dir_15947426, "/"), stdout=TRUE, stderr=TRUE)
+
+# Load the local CSV file(s) as a data frame.
+dataset_15947426_survey_df = data.table::rbindlist(lapply(Sys.glob(export_15947426_glob), data.table::fread))
+
+head(dataset_15947426_survey_df)

--- a/dataset-snippets/codegen_sample.r
+++ b/dataset-snippets/codegen_sample.r
@@ -96,7 +96,7 @@ dataset_15947426_survey_df <- bind_rows(
   map(system2('gsutil', args = c('ls', survey_export_15947426_path), stdout = TRUE, stderr = TRUE),
       function(csv) {
         message(str_glue('Loading {csv}.'))
-        chunk <- read_csv(pipe(str_glue('gsutil cat {csv}')), col_types = col_types)
+        chunk <- read_csv(pipe(str_glue('gsutil cat {csv}')), col_types = col_types, show_col_types = FALSE)
         if (is.null(col_types)) {
           col_types <- spec(chunk)    
         }

--- a/dataset-snippets/codegen_sample.r
+++ b/dataset-snippets/codegen_sample.r
@@ -91,11 +91,16 @@ bq_table_save(
 # Read the data directly from Cloud Storage into memory.
 # NOTE: Alternatively you can `gsutil -m cp {survey_export_15947426_path}` to copy these files
 #       to the Jupyter disk.
+col_types <- NULL
 dataset_15947426_survey_df <- bind_rows(
   map(system2('gsutil', args = c('ls', survey_export_15947426_path), stdout = TRUE, stderr = TRUE),
       function(csv) {
         message(str_glue('Loading {csv}.'))
-        read_csv(pipe(str_glue('gsutil cat {csv}')), col_types = cols(person_id=col_double())
+        chunk <- read_csv(pipe(str_glue('gsutil cat {csv}')), col_types = col_types)
+        if (is.null(col_types)) {
+          col_types <- spec(chunk)    
+        }
+        chunk
       })
 )
 

--- a/dataset-snippets/codegen_sample.r
+++ b/dataset-snippets/codegen_sample.r
@@ -95,7 +95,7 @@ dataset_15947426_survey_df <- bind_rows(
   map(system2('gsutil', args = c('ls', survey_export_15947426_path), stdout = TRUE, stderr = TRUE),
       function(csv) {
         message(str_glue('Loading {csv}.'))
-        read_csv(pipe(str_glue('gsutil cat {csv}')))
+        read_csv(pipe(str_glue('gsutil cat {csv}')), col_types = cols(person_id=col_double())
       })
 )
 


### PR DESCRIPTION
**For review only**. I do not intend to merge this.

## The problem

Currently, the AoU R codegen uses `bq_table_download()`. This is slow, but mostly works. However, with some recent bigrquery package changes (https://github.com/r-dbi/bigrquery/issues/461), it has become apparent that the package behaves poorly in cases where BigQuery returns pages smaller than the requested page size. Previously, it seems this resulted in silent data issues; now it results in an error (reported by AoU users).

This does not look like a quick fix in the package, and the package documentation also recommends using a CSV-based approach for larger datasets anyways https://www.rdocumentation.org/packages/bigrquery/versions/1.4.0/topics/bq_table_download

## Proposed solution

Change the AoU R codegen to instead:

- Export the query results to GCS as CSV
- Localize the CSV
- Load CSV shards as dataframes and concat

## Known issues

- Previously, we coerced all BigQuery numbers to the int64 type; this avoids potential issues with large table IDs (concept IDs, etc). I don't see an easy way to do this; likely my approach would coerce all number columns in the dataframe to int64 explicitly.