### PR TITLE
Improve error handling when copying to/from bucket

### DIFF
--- a/storage-snippets/copy_data_to_workspace_bucket.py
+++ b/storage-snippets/copy_data_to_workspace_bucket.py
@@ -3,7 +3,7 @@
 # This code saves your dataframe into a csv file in a "data" folder in Google Bucket
 
 # Replace df with THE NAME OF YOUR DATAFRAME
-my_dataframe = df   
+my_dataframe = df
 
 # Replace 'test.csv' with THE NAME of the file you're going to store in the bucket (don't delete the quotation marks)
 destination_filename = 'test.csv'
@@ -24,5 +24,8 @@ my_bucket = os.getenv('WORKSPACE_BUCKET')
 args = ["gsutil", "cp", f"./{destination_filename}", f"{my_bucket}/data/"]
 output = subprocess.run(args, capture_output=True)
 
-# print output from gsutil
-output.stderr
+if output.returncode != 0:
+    # failed to copy the file - add appropriate error handling here
+    print(output.stderr)
+else:
+    print(f"File {destination_filename} copied to {my_bucket}/data/")

--- a/storage-snippets/copy_file_from_workspace_bucket.py
+++ b/storage-snippets/copy_file_from_workspace_bucket.py
@@ -15,9 +15,13 @@ name_of_file_in_bucket = 'test.csv'
 my_bucket = os.getenv('WORKSPACE_BUCKET')
 
 # copy csv file from the bucket to the current working space
-os.system(f"gsutil cp '{my_bucket}/data/{name_of_file_in_bucket}' .")
+args = ["gsutil", "cp", f"{my_bucket}/data/{name_of_file_in_bucket}", "."]
+output = subprocess.run(args, capture_output=True)
 
-print(f'[INFO] {name_of_file_in_bucket} is successfully downloaded into your working space')
-# save dataframe in a csv file in the same workspace as the notebook
-my_dataframe = pd.read_csv(name_of_file_in_bucket)
-my_dataframe.head()
+if output.returncode != 0:
+    # failed to copy the file - add appropriate error handling here
+    print(output.stderr)
+else:
+    print(f'[INFO] {name_of_file_in_bucket} is successfully downloaded into your working space')
+    my_dataframe = pd.read_csv(name_of_file_in_bucket)
+    my_dataframe.head()


### PR DESCRIPTION
Add explicit error handling when copying files to/from the workspace bucket:

- Use subprocess.run in both snippets to capture the exit code
- Add example of testing the error code to handle errors
