### PR TITLE
Unable to access cromshell_config.json if cromwell_server  is set to empty string

### DIFF
--- a/py/py_cromwell_setup.py
+++ b/py/py_cromwell_setup.py
@@ -83,7 +83,7 @@ def configure_cromwell(env, proxy_url):
      print('Updating cromwell config')
      file = f'{str(Path.home())}/.cromshell/cromshell_config.json'
      configuration = {
-        'cromwell_server': proxy_url.split("swagger/", 1)[0] if proxy_url else "",
+        'cromwell_server': proxy_url.split("swagger/", 1)[0] if proxy_url else " ",
         'requests_timeout': 5,
         'gcloud_token_email': env['user_email'],
         'referer_header_url': env['leonardo_url']

--- a/py/py_cromwell_setup.py
+++ b/py/py_cromwell_setup.py
@@ -83,7 +83,7 @@ def configure_cromwell(env, proxy_url):
      print('Updating cromwell config')
      file = f'{str(Path.home())}/.cromshell/cromshell_config.json'
      configuration = {
-        'cromwell_server': proxy_url.split("swagger/", 1)[0] if proxy_url else " ",
+        'cromwell_server': proxy_url.split("swagger/", 1)[0] if proxy_url else "invalid url",
         'requests_timeout': 5,
         'gcloud_token_email': env['user_email'],
         'referer_header_url': env['leonardo_url']

--- a/r/r_cromwell_setup.R
+++ b/r/r_cromwell_setup.R
@@ -94,7 +94,7 @@ configure_cromwell <- function(env, proxy_url) {
   cat("Updating cromwell config\n")
   file_path <- file.path(path.expand("~"), ".cromshell", "cromshell_config.json")
   configuration <- list(
-    cromwell_server = ifelse(!is.null(proxy_url), proxy_url, " "),
+    cromwell_server = ifelse(!is.null(proxy_url), proxy_url, "invalid url"),
     requests_timeout = 5,
     gcloud_token_email = env$user_email,
     referer_header_url = env$leonardo_url

--- a/r/r_cromwell_setup.R
+++ b/r/r_cromwell_setup.R
@@ -94,7 +94,7 @@ configure_cromwell <- function(env, proxy_url) {
   cat("Updating cromwell config\n")
   file_path <- file.path(path.expand("~"), ".cromshell", "cromshell_config.json")
   configuration <- list(
-    cromwell_server = ifelse(!is.null(proxy_url), proxy_url, ""),
+    cromwell_server = ifelse(!is.null(proxy_url), proxy_url, " "),
     requests_timeout = 5,
     gcloud_token_email = env$user_email,
     referer_header_url = env$leonardo_url


### PR DESCRIPTION
If Cromwell is not running in the workbench, executing the Cromwell snippet will result in the value of 'cromwell_server' in 'cromshell_config.json' being set to an empty string.

This empty value will cause the snippet to fail when attempting to run commands such as 'cromshell-alpha version' or 'cromshell-beta version' in subsequent runs.


Workbench PR: https://github.com/all-of-us/workbench/pull/7596
Unfortunately we don't have automated testing configured for the code in this
repository yet so we set up this checklist as an *automatic reminder*:

- [ ] Ensure that the smoke tests pass using the current (or upcoming) CDR
- [ ] Update documentation relevant to this pull request

Questions? See [CONTRIBUTING.md](https://github.com/all-of-us/workbench-snippets/blob/master/CONTRIBUTING.md)
or file an issue so that we can get it documented!
